### PR TITLE
Update the standalone egg_net to an appropriate ChainIdentifier

### DIFF
--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -871,7 +871,7 @@ impl pallet_dkg_metadata::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ChainIdentifier: TypedChainId = TypedChainId::RococoParachain(5);
+	pub const ChainIdentifier: TypedChainId = TypedChainId::Substrate(1081);
 	pub const ProposalLifetime: BlockNumber = HOURS / 5;
 	pub const DKGAccountId: PalletId = PalletId(*b"dw/dkgac");
 	pub const RefreshDelay: Permill = Permill::from_percent(90);


### PR DESCRIPTION
This changes the ChainIdentifier of the standalone runtime to a value which is different than protocol_substrate's.