### PR TITLE
Fix chain type and script for running standalone node

### DIFF
--- a/scripts/run-standalone.sh
+++ b/scripts/run-standalone.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "*** Start Webb Standalone Node ***"
+./target/release/egg-standalone-node --dev --alice --node-key 0000000000000000000000000000000000000000000000000000000000000001 &
+./target/release/egg-standalone-node --dev --bob --port 33334 --tmp   --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp

--- a/scripts/run-standalone.sh
+++ b/scripts/run-standalone.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-echo "*** Start Webb Standalone Node ***"
+echo "*** Start Egg Standalone Node ***"
 ./target/release/egg-standalone-node --dev --alice --node-key 0000000000000000000000000000000000000000000000000000000000000001 &
 ./target/release/egg-standalone-node --dev --bob --port 33334 --tmp   --bootnodes /ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp

--- a/standalone/runtime/src/protocol_substrate_config.rs
+++ b/standalone/runtime/src/protocol_substrate_config.rs
@@ -166,7 +166,7 @@ parameter_types! {
 	pub const AnchorPalletId: PalletId = PalletId(*b"py/anchr");
 	pub const HistoryLength: u32 = 30;
 	// Substrate parachain chain ID type
-	pub const ChainType: [u8; 2] = [2, 1];
+	pub const ChainType: [u8; 2] = [2, 0];
 	pub const ChainIdentifier: ChainId = 1080;
 }
 


### PR DESCRIPTION
# Overview
Fixing chain type to be `[2,0]` for standalone runtime and added script for running the standalone node